### PR TITLE
Update publish-to-github-packages.yml

### DIFF
--- a/.github/workflows/publish-to-github-packages.yml
+++ b/.github/workflows/publish-to-github-packages.yml
@@ -27,7 +27,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/${{ github.repository_owner }}/easy-icecast2
+          images: ghcr.io/${{ github.repository_owner }}/audio-server
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/publish-to-github-packages.yml` file to update the Docker image name.

* Updated the Docker image name in the `jobs:` section from `easy-icecast2` to `audio-server` to reflect the new project name. (`.github/workflows/publish-to-github-packages.yml`)