### PR TITLE
Rename breezeicecast2 to audio-server and add Icecast configuration variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,13 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
+    environment:
+      - ICECAST_SOURCE_PASSWORD=your_source_password
+      - ICECAST_ADMIN_PASSWORD=your_admin_password
+      - ICECAST_RELAY_PASSWORD=your_relay_password
+      - ICECAST_ADMIN_USERNAME=admin
+      - ICECAST_ADMIN_EMAIL=admin@example.com
+      - ICECAST_LOCATION=Your Location
+      - ICECAST_HOSTNAME=localhost
+      - ICECAST_MAX_CLIENTS=100
+      - ICECAST_MAX_SOURCES=2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   audio-server:
-    image: bu-audioserver
+    image: audio-server
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.4'
 
 services:
-  breezeicecast2:
-    image: breezeicecast2
+  audio-server:
+    image: bu-audioserver
     build:
       context: .
       dockerfile: ./Dockerfile


### PR DESCRIPTION
Update the service name in the Docker Compose file and include necessary environment variables for Icecast configuration.